### PR TITLE
Dominant Speaker fix and video removal

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ var compression = require('compression')
 var http = require('http');
 var https = require('https');
 var fs = require('fs');
-import Config from ('./config')
+var Config = require('./config')
 
 var app = express()
 
@@ -21,7 +21,10 @@ var PORT = process.env.PORT || 8080
 /*app.listen(PORT, function() {
   console.log('Production Express server running at localhost:' + PORT)
 })*/
-var options = Config.options
+var options = {
+  key: fs.readFileSync(Config.options.key),
+  cert: fs.readFileSync(Config.options.cert)
+}
 
 app.server = https.createServer(options, app);
 

--- a/src/actions/video-control-actions.js
+++ b/src/actions/video-control-actions.js
@@ -1,6 +1,6 @@
 import VideoControlConstants from '../constants/video-control-constants';
 
-const changeMainView = (videoType, videoIndex, localVideos, remoteVideos) => ({
+export const changeMainView = (videoType, videoIndex, localVideos, remoteVideos) => ({
     type: VideoControlConstants.VIDEO_CONTROL_CHANGE_MAIN_VIEW,
     data: {
       videoType,
@@ -10,4 +10,9 @@ const changeMainView = (videoType, videoIndex, localVideos, remoteVideos) => ({
     }
 })
 
-export default changeMainView
+export const changeDominantSpeaker = (dominantSpeakerIndex) => ({
+  type: VideoControlConstants.VIDEO_CONTROL_UPDATE_DOMINANT_SPEAKER,
+  data: {
+    dominantSpeakerIndex
+  }
+})

--- a/src/components/black-box/black-box.css
+++ b/src/components/black-box/black-box.css
@@ -1,0 +1,27 @@
+.black-box {
+  //float: right;
+  margin-left: 5px;
+  margin-right: 5px;
+  display: inline-block;
+  background-color: #000000; /*wheat;*/
+  position: relative;
+  width: auto;
+  //max-height: 120px;
+  //min-height: 120px;
+  text-align: center;
+  vertical-align: top;
+}
+
+.black-box .user-text {
+  width: auto;
+  max-height: 120px;
+  min-height: 120px;
+  border-radius: 3px;
+  border: 1px solid #000000;
+}
+
+.black-box:hover {
+  box-shadow: inset 0 0 5px #111111, 0 0 10px #111111, inset 0 0 80px #006d91;
+  border: 1px solid #000000;
+  background-color: #82b9d6;
+}

--- a/src/components/black-box/index.js
+++ b/src/components/black-box/index.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import './black-box.css'
+
+const BlackBox = ({userName}) => (
+  <div className="black-box">
+    <div className="user-text">
+    Dom Speaker: {userName}
+    </div>
+  </div>
+);
+
+BlackBox.propTypes = {
+  userName: PropTypes.string.isRequired
+}
+
+export default BlackBox

--- a/src/components/main.js
+++ b/src/components/main.js
@@ -3,6 +3,7 @@ import MainVideo from './main-video';
 import MeetToolbar from '../containers/meet-toolbar';
 import HorizontalWrapper from './horizontal-wrapper';
 import HorizontalBox from '../containers/horizontal-box';
+import BlackBox from '../components/black-box'
 import LoginPanel from '../containers/login-panel';
 import { withRouter } from 'react-router';
 import withWebRTC, { LocalVideo, RemoteVideo, WebRTCConstants } from 'iris-react-webrtc';
@@ -139,6 +140,9 @@ componentWillReceiveProps = (nextProps) => {
   if (nextProps.accessToken !== this.props.accessToken) {
        this._userLoggedIn();
      }
+  // if (nextProps.dominantSpeakerIndex && nextProps.dominantSpeakerIndex !== this.props.dominantSpeakerIndex) {
+  //   this._onDominantSpeakerChanged(nextProps.dominantSpeakerIndex);
+  // }
 }
 
   componentWillUnmount() {
@@ -397,7 +401,7 @@ _isDominant(index) {
                 <LocalVideo key={connection.video.index} video={connection.video} audio={connection.audio} />
               </HorizontalBox>
             )
-            : ( null ) ;
+            : ( <BlackBox key={connection.video.index} userName={this.props.userName}> </BlackBox>  ) ;
           })}
           {this.props.remoteVideos.map((connection) => {
             console.log('REMOTE CONNECTION');
@@ -415,7 +419,7 @@ _isDominant(index) {
                   <RemoteVideo key={connection.video.index} video={connection.video} audio={connection.audio} />
                 </HorizontalBox>
               )
-              : ( null ) ;
+              : ( <BlackBox key={connection.video.index} userName={this.props.userName}> </BlackBox> ) ;
             }
           })}
       </HorizontalWrapper>

--- a/src/constants/video-control-constants.js
+++ b/src/constants/video-control-constants.js
@@ -3,6 +3,7 @@ import KeyMirror from 'keymirror';
 const VideoControlStoreConstants = {
   VIDEO_CONTROL_CHANGE_MAIN_VIEW: null,
   VIDEO_CONTROL_MAIN_VIEW_UPDATED_EVENT: null,
+  VIDEO_CONTROL_UPDATE_DOMINANT_SPEAKER: null
 }
 
 export default KeyMirror(VideoControlStoreConstants);

--- a/src/containers/horizontal-box.js
+++ b/src/containers/horizontal-box.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import VideoControlActions from '../actions/video-control-actions';
+import { changeMainView } from '../actions/video-control-actions';
 import HorizontalBoxComponent from '../components/horizontal-box';
 import { connect } from 'react-redux'
 
 let clickHandlerCreator = function(dispatch) {
   let clickHandler = function(type, id, localVideos, remoteVideos) {
-    dispatch(VideoControlActions(type, id, localVideos, remoteVideos))
+    dispatch(changeMainView(type, id, localVideos, remoteVideos))
   };
 
   return clickHandler

--- a/src/reducers/video-control-reducer.js
+++ b/src/reducers/video-control-reducer.js
@@ -15,12 +15,18 @@ const VideoReducer = (state = {}, action) => {
             return connection.video.index === action.data.videoIndex;
             });
           }
-        return {
-          videoType: action.data.videoType,
-          videoIndex: action.data.videoIndex,
-          connection: mainConnection
-        }
-      } else {
+        // return {
+        //   videoType: action.data.videoType,
+        //   videoIndex: action.data.videoIndex,
+        //   connection: mainConnection
+        // }
+          return Object.assign({}, state, {
+               videoType: action.data.videoType,
+               videoIndex: action.data.videoIndex,
+               connection: mainConnection
+             })
+          }
+       else {
         console.log('Invalid data object passed to VideoControlReducer. Returning previous state.')
         console.log('Action: ' + action);
         return state;

--- a/src/reducers/video-control-reducer.js
+++ b/src/reducers/video-control-reducer.js
@@ -21,9 +21,21 @@ const VideoReducer = (state = {}, action) => {
           connection: mainConnection
         }
       } else {
-        console.log('Invalid data object passed to VideoControlReducer. Returning current state')
+        console.log('Invalid data object passed to VideoControlReducer. Returning previous state.')
         console.log('Action: ' + action);
         return state;
+      }
+
+    case VideoControlConstants.VIDEO_CONTROL_UPDATE_DOMINANT_SPEAKER:
+      if (action.data.dominantSpeakerIndex) {
+        console.log("changing dominant speaker to: " + action.data.dominantSpeakerIndex)
+        return Object.assign({}, state, {
+          dominantSpeakerIndex: action.data.dominantSpeakerIndex
+        })
+      }
+      else {
+        console.log("Invalid dominant speaker index passed to VideoControlReducer. Returning previous state.")
+        return state
       }
 
     default:


### PR DESCRIPTION
- Fixed the issue with identifying the dominant speaker index
- Made the dominant speaker index update via redux store
- Added conditional rendering of horizontal-box: if not dominant speaker then render. If dominant speaker, return null. Next step in the process will be to actually add a placeholder (like a black box) to the footer instead of completely removing the small video.