### PR TITLE
Enable dominant speaker with the new SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "flux": "^2.1.1",
     "font-awesome": "^4.3.0",
     "iris-auth-js-sdk": "1.0.8",
-    "iris-react-webrtc": "1.0.23",
+    "iris-react-webrtc": "1.0.25",
     "keymirror": "^0.1.1",
     "lodash": "^3.6.0",
     "react": "^15.5.4",

--- a/sdk.config.json
+++ b/sdk.config.json
@@ -1,6 +1,0 @@
-{
-  "eventManagerUrl": "sdk-evm-wcdc-c-001.rtc.sys.comcast.net",
-  "notificationServer": "sdk-ntm-wcdc-c-001.rtc.sys.comcast.net",
-  "authUrl": "https://sdk-aum-wcdc-c-001.rtc.sys.comcast.net/v1/",
-  "appKey": "0cwkyz8Twnhy1dR+R7M5oocCCdwOqGya"
-}

--- a/src/components/black-box/black-box.css
+++ b/src/components/black-box/black-box.css
@@ -8,11 +8,14 @@
   width: auto;
   //max-height: 120px;
   //min-height: 120px;
+  min-width: 160px;
   text-align: center;
   vertical-align: top;
+  border-radius: 3px;
 }
 
 .black-box .user-text {
+  color: #ffffff;
   width: auto;
   max-height: 120px;
   min-height: 120px;

--- a/src/components/black-box/index.js
+++ b/src/components/black-box/index.js
@@ -1,3 +1,4 @@
+
 import React from 'react'
 import PropTypes from 'prop-types'
 import './black-box.css'
@@ -5,7 +6,8 @@ import './black-box.css'
 const BlackBox = ({userName}) => (
   <div className="black-box">
     <div className="user-text">
-    Dom Speaker: {userName}
+      <div>Current Speaker:</div>
+      <p>{userName}</p>
     </div>
   </div>
 );

--- a/src/components/black-box/index.js
+++ b/src/components/black-box/index.js
@@ -3,8 +3,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import './black-box.css'
 
-const BlackBox = ({userName}) => (
-  <div className="black-box">
+const BlackBox = ({userName, onClick}) => (
+  <div className="black-box" onClick={onClick}>
     <div className="user-text">
       <div>Current Speaker:</div>
       <p>{userName}</p>
@@ -13,7 +13,8 @@ const BlackBox = ({userName}) => (
 );
 
 BlackBox.propTypes = {
-  userName: PropTypes.string.isRequired
+  userName: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired
 }
 
 export default BlackBox

--- a/src/components/main.js
+++ b/src/components/main.js
@@ -3,7 +3,7 @@ import MainVideo from './main-video';
 import MeetToolbar from '../containers/meet-toolbar';
 import HorizontalWrapper from './horizontal-wrapper';
 import HorizontalBox from '../containers/horizontal-box';
-import BlackBox from '../components/black-box'
+import BlackBox from '../containers/black-box'
 import LoginPanel from '../containers/login-panel';
 import { withRouter } from 'react-router';
 import withWebRTC, { LocalVideo, RemoteVideo, WebRTCConstants } from 'iris-react-webrtc';
@@ -362,7 +362,13 @@ componentWillReceiveProps = (nextProps) => {
                 <LocalVideo key={connection.id} video={connection} audio={connection.audio} />
               </HorizontalBox>
             )
-            : ( <BlackBox key={connection.id} userName={this.props.userName}> </BlackBox>  ) ;
+            : ( <BlackBox
+              key={connection.id}
+              userName={this.props.userName}
+              type='local'
+              id={connection.id}
+              localVideos={this.props.localVideos}
+              remoteVideos = {this.props.remoteVideos}> </BlackBox>  ) ;
           })}
           {this.props.remoteVideos.map((connection) => {
 
@@ -379,7 +385,13 @@ componentWillReceiveProps = (nextProps) => {
                   <RemoteVideo key={connection.id} video={connection} audio={connection.audio} />
                 </HorizontalBox>
               )
-              : ( <BlackBox key={connection.id} userName={this.props.userName}> </BlackBox> ) ;
+              : ( <BlackBox
+                key={connection.id}
+                userName={this.props.userName}
+                type='remote'
+                id={connection.id}
+                localVideos={this.props.localVideos}
+                remoteVideos={this.props.remoteVideos} > </BlackBox> ) ;
             }
           })}
       </HorizontalWrapper>

--- a/src/components/main.js
+++ b/src/components/main.js
@@ -147,7 +147,7 @@ componentWillReceiveProps = (nextProps) => {
   _onLocalVideo(videoInfo) {
     console.log('NUMBER OF LOCAL VIDEOS: ' + this.props.localVideos.length);
     if (this.props.localVideos.length > 0) {
-      this.props.VideoControl('local', this.props.localVideos.id, this.props.localVideos, this.props.remoteVideos)
+      this.props.VideoControl('local', this.props.localVideos[0].id, this.props.localVideos, this.props.remoteVideos)
     }
   }
 
@@ -180,55 +180,30 @@ componentWillReceiveProps = (nextProps) => {
     }
   }
 
-  // _onDominantSpeakerChanged(dominantSpeakerEndpoint) {
-  //   console.log('DOMINANT_SPEAKER_CHANGED: ' + dominantSpeakerEndpoint);
-  //   //let participant = track.getParticipantId();
-  //   //let baseId = participant.replace(/(-.*$)|(@.*$)/,'');
-  //     const matchedConnection = this.props.remoteVideos.find((connection) => {
-  //       const participantId = connection.track.getParticipantId();
-  //       console.log('participantId: ' + participantId);
-  //       dominantSpeakerEndpoint = dominantSpeakerEndpoint.substring(0, dominantSpeakerEndpoint.lastIndexOf("@"))
-  //       const endPoint = participantId.substring(0, participantId.lastIndexOf("@"))
-  //       console.log("endpoint and dom: " + endPoint + " " + dominantSpeakerEndpoint)
-  //       return endPoint === dominantSpeakerEndpoint;
-  //   });
-  //
-  //   console.log('FOUND DOMINANT SPEAKER: ');
-  //   console.log(matchedConnection);
-  //   if (matchedConnection) {
-  //     this.props.VideoControl('remote', matchedConnection.video.index, this.props.localVideos, this.props.remoteVideos)
-  //
-  //   } else if (this.props.localVideos.length > 0) {
-  //     // no remote participants found so assume it is local speaker
-  //     this.props.VideoControl('local', this.props.localVideos[0].video.index, this.props.localVideos, this.props.remoteVideos)
-  //   }
-  // }
-
   _onDominantSpeakerChanged(dominantSpeakerEndpoint) {
-    console.log('DOMINANT_SPEAKER_CHANGED: ', dominantSpeakerEndpoint);
     //let participant = track.getParticipantId();
     //let baseId = participant.replace(/(-.*$)|(@.*$)/,'');
       const matchedConnection = this.props.remoteVideos.find((connection) => {
-        const participantId = connection.track.getParticipantId();
-        console.log('participantId: ' + participantId);
+        let participantId = connection.participantJid;
+        participantId = participantId.substring(participantId.indexOf("/")+1, participantId.indexOf("@iris-meet.comcast.com"))
+        //participantId = participantId.substring(0, participantId.indexOf("/"))
         dominantSpeakerEndpoint = dominantSpeakerEndpoint.substring(0, dominantSpeakerEndpoint.lastIndexOf("@"))
-        const endPoint = participantId.substring(0, participantId.lastIndexOf("@"))
-        console.log("endpoint and dom: " + endPoint + " " + dominantSpeakerEndpoint)
+        const endPoint = participantId.substring(participantId.lastIndexOf("/")+1)
+        console.log("endpoint and dom: " + endPoint + ", " + dominantSpeakerEndpoint)
         return endPoint === dominantSpeakerEndpoint;
     });
 
     console.log('FOUND DOMINANT SPEAKER: ');
     console.log(matchedConnection);
     if (matchedConnection) {
-      this.props.VideoControl('remote', matchedConnection.video.index, this.props.localVideos, this.props.remoteVideos)
-      //??
-      this.props.changeDominantSpeaker(matchedConnection.video.index)
+      this.props.VideoControl('remote', matchedConnection.id, this.props.localVideos, this.props.remoteVideos)
+      this.props.changeDominantSpeaker(matchedConnection.id)
 
     } else if (this.props.localVideos.length > 0) {
       // no remote participants found so assume it is local speaker
-      this.props.VideoControl('local', this.props.localVideos[0].video.index, this.props.localVideos, this.props.remoteVideos)
+      this.props.VideoControl('local', this.props.localVideos[0].id, this.props.localVideos, this.props.remoteVideos)
       //??
-      this.props.changeDominantSpeaker(this.props.localVideos[0].video.index)
+      this.props.changeDominantSpeaker(this.props.localVideos[0].id)
     }
   }
 
@@ -338,63 +313,13 @@ componentWillReceiveProps = (nextProps) => {
   }
 
   _isDominant(index) {
-    console.log('inside isDominant')
-    console.log('index === this.props.dominantSpeakerIndex: ' + index + " === " + this.props.dominantSpeakerIndex + " ?")
     console.log(index === this.props.dominantSpeakerIndex)
     return index === this.props.dominantSpeakerIndex;
   }
 
-/*
-return !this._isDominant(connection.video.index) ? (
-  <HorizontalBox
-    key={connection.video.index}
-    type='local'
-    id={connection.video.index}
-    localVideos = {this.props.localVideos}
-    remoteVideos = {this.props.remoteVideos}
-  >
-    <LocalVideo key={connection.id} video={connection} />
-  </HorizontalBox>
-)
-: ( <BlackBox key={connection.video.index} userName={this.props.userName}> </BlackBox>  ) ;
-*/
-
-
-/* REMOTE
-if (connection.video) {
-  return !this._isDominant(connection.video.index) ? (
-    <HorizontalBox
-      key={connection.video.index}
-      type='remote'
-      id={connection.video.index}
-      localVideos = {this.props.localVideos}
-      remoteVideos = {this.props.remoteVideos}
-    >
-      <RemoteVideo key={connection.video.index} video={connection.video} audio={connection.audio} />
-    </HorizontalBox>
-  )
-  : ( <BlackBox key={connection.video.index} userName={this.props.userName}> </BlackBox> ) ;
-}
-*/
-
-/* MAIN
-<MainVideo>
-  {this.props.videoType === 'remote' ?
-    <RemoteVideo
-      video={this.props.connection.video}
-      audio={this.props.connection.audio}
-    /> : null
-  }
-  {this.props.videoType === 'local' ?
-    <LocalVideo
-      video={this.props.connection.video}
-      audio={this.props.connection.audio}
-    /> : null
-  }
-</MainVideo>
-*/
 
   render() {
+
     return (
       <div onMouseMove={this._onMouseMove.bind(this)}>
       {this.props.localVideos.length > 0 ?
@@ -409,13 +334,13 @@ if (connection.video) {
       <MainVideo>
         {this.props.videoType === 'remote' ?
           <RemoteVideo
-            video={this.props.connection.video}
+            video={this.props.connection}
             audio={this.props.connection.audio}
           /> : null
         }
         {this.props.videoType === 'local' ?
           <LocalVideo
-            video={this.props.connection.video}
+            video={this.props.localVideos[0]}
             audio={this.props.connection.audio}
           /> : null
         }
@@ -426,7 +351,7 @@ if (connection.video) {
             console.log('LOCAL CONNECTION');
             console.log(connection);
 
-            return (
+            return !this._isDominant(connection.id) ? (
               <HorizontalBox
                 key={connection.id}
                 type='local'
@@ -434,24 +359,28 @@ if (connection.video) {
                 localVideos = {this.props.localVideos}
                 remoteVideos = {this.props.remoteVideos}
               >
-                <LocalVideo key={connection.id} video={connection} />
+                <LocalVideo key={connection.id} video={connection} audio={connection.audio} />
               </HorizontalBox>
             )
+            : ( <BlackBox key={connection.id} userName={this.props.userName}> </BlackBox>  ) ;
           })}
           {this.props.remoteVideos.map((connection) => {
-            console.log('REMOTE CONNECTION');
-            console.log(connection);
-            return (
-              <HorizontalBox
-                key={connection.id}
-                type='remote'
-                id={connection.id}
-                localVideos = {this.props.localVideos}
-                remoteVideos = {this.props.remoteVideos}
-              >
-                <RemoteVideo key={connection.id} video={connection} />
-              </HorizontalBox>
-            );
+
+
+            if (connection) {
+              return !this._isDominant(connection.id) ? (
+                <HorizontalBox
+                  key={connection.id}
+                  type='remote'
+                  id={connection.id}
+                  localVideos = {this.props.localVideos}
+                  remoteVideos = {this.props.remoteVideos}
+                >
+                  <RemoteVideo key={connection.id} video={connection} audio={connection.audio} />
+                </HorizontalBox>
+              )
+              : ( <BlackBox key={connection.id} userName={this.props.userName}> </BlackBox> ) ;
+            }
           })}
       </HorizontalWrapper>
       {this.state.showUser || this.state.showRoom ?

--- a/src/containers/black-box.js
+++ b/src/containers/black-box.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { changeMainView } from '../actions/video-control-actions';
+import BlackBoxComponent from '../components/black-box';
+import { connect } from 'react-redux'
+
+let clickHandlerCreator = function(dispatch) {
+  let clickHandler = function(type, id, localVideos, remoteVideos) {
+    dispatch(changeMainView(type, id, localVideos, remoteVideos))
+  };
+
+  return clickHandler
+}
+
+class BlackBox extends React.Component {
+  constructor(props) {
+  super(props);
+  this.clickHandler = clickHandlerCreator(this.props.dispatch);
+  }
+
+  render() {
+    return (
+      <BlackBoxComponent userName={this.props.userName} onClick={() =>this.clickHandler(this.props.type, this.props.id, this.props.localVideos, this.props.remoteVideos)}>
+      </BlackBoxComponent>
+    )
+  }
+}
+
+export default connect()(BlackBox);

--- a/src/reducers/user-reducer.js
+++ b/src/reducers/user-reducer.js
@@ -14,14 +14,13 @@ Format of this reducer's part of state tree:
 */
 
 const UserReducer = (state = {}, action) => {
-  console.log('ACTIONS!');
+  console.log('Received action: ')
   console.log(action);
   switch(action.type) {
       case UserStoreConstants.USER_LOGIN:
         if (action.data && action.data.userName &&
             action.data.routingId && action.data.roomName &&
             action.data.accessToken && action.data.decodedToken) {
-              console.log('action.data: ' +action.data)
             return {
               userName: action.data.userName,
               routingId: action.data.routingId,


### PR DESCRIPTION
- Changed rendering code for HorizontalBox elements and MainVideo to work with the new SDK
- Edited the substring extraction code for determining dominant speaker
- Fixed a local video indexing bug that prevented local videos from going to the main view

Still need to work on:
- dominant speaker identification seems to work well with 2 speakers but is inconsistent with more speakers.
- while the dominant speaker is displayed in the main video, if you click on another video and then try to go back to the dominant speaker, the main view will not change.  (edit: fixed)