### PR TITLE
Minor changes to HorizontalWrapper

### DIFF
--- a/src/components/black-box/index.js
+++ b/src/components/black-box/index.js
@@ -6,8 +6,7 @@ import './black-box.css'
 const BlackBox = ({userName, onClick}) => (
   <div className="black-box" onClick={onClick}>
     <div className="user-text">
-      <div>Current Speaker:</div>
-      <p>{userName}</p>
+      <div>Current Speaker</div>
     </div>
   </div>
 );

--- a/src/components/main.js
+++ b/src/components/main.js
@@ -351,7 +351,7 @@ componentWillReceiveProps = (nextProps) => {
             console.log('LOCAL CONNECTION');
             console.log(connection);
 
-            return !this._isDominant(connection.id) ? (
+            return (!this._isDominant(connection.id) && this.props.remoteVideos.length > 0) ? (
               <HorizontalBox
                 key={connection.id}
                 type='local'


### PR DESCRIPTION
- If only one user in the room (only local), no video gets displayed in the footer, only the blackbox corresponding to the local video
- For now, username is removed from the blackbox because it was fetched from local storage and a given user would only see his/her username instead of the others' as well