### PR TITLE
Inline installation of chrome extension

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ var options = {
   cert: fs.readFileSync(Config.options.cert)
 }
 
+
 app.server = https.createServer(options, app);
 
 app.server.listen('443', '0.0.0.0', () => {

--- a/src/actions/video-control-actions.js
+++ b/src/actions/video-control-actions.js
@@ -16,3 +16,10 @@ export const changeDominantSpeaker = (dominantSpeakerId) => ({
     dominantSpeakerId
   }
 })
+
+export const changeExtInstalledState = (extInstalled) => ({
+  type: VideoControlConstants.VIDEO_CONTROL_EXTENSION_STATUS,
+  data: {
+    extInstalled
+  }
+})

--- a/src/components/main.js
+++ b/src/components/main.js
@@ -91,7 +91,6 @@ export default connect(mapStateToProps, mapDispatchToProps)(withWebRTC(withRoute
     }, 10000);
 
     const this_constructor = this;
-    let screenShareExtInstalled = false
     this._isExtInstalled().then(function(response) {
       console.log("Found desktop share extension. Version ", response);
       this_constructor.props.changeExtensionStatus(true)
@@ -377,7 +376,6 @@ _onReceivedNewId(data) {
 _isExtInstalled() {
   //const extId = 'ninfhlnofdcigedlpjkgkfchccfikdnf'; //experimental
   const extId = 'ofekpehdpllklhgnipjhnoagibfdicjb'; //from web store
-  var hasExtension = false;
 
   return new Promise(function(resolve, reject) {
     window.chrome.runtime.sendMessage(
@@ -446,8 +444,8 @@ _isExtInstalled() {
 
 
 _shareScreen() {
+  console.log("beginning of _shareScreen")
   const this_main = this;
-  let constraints = {};
   let screenShareStarted = false //updated to true/false depending on extension response
 
   const extId = 'ofekpehdpllklhgnipjhnoagibfdicjb'; //from web store
@@ -471,24 +469,14 @@ _shareScreen() {
            else {
            console.log('Response from extension: ', response);
 
-           //These constraints are not necessary,
-           //they are being rebuilt inside startScreenShare function
-           //But I'm leaving them here for now anyways
-           constraints.audio = false;
-           constraints.video = {
-               mandatory: {
-                   chromeMediaSource: "desktop",
-                   chromeMediaSourceId: response.streamId,
-                   maxWidth: window.screen.width,
-                   maxHeight: window.screen.height,
-                   maxFrameRate: 3
-               },
-               optional: []
-           };
 
            if (response && response.streamId !== "") {
-             this_main.startScreenShare(response.streamId)
+             console.log("Extension responded with ID: ", response.streamId)
              screenShareStarted = true
+             this_main.startScreenShare(response.streamId)
+             this_main.setState({
+               isSharingScreen: screenShareStarted
+             });
            }
            else {
              console.log("Invalid streamId --> not starting screen share")
@@ -575,6 +563,7 @@ _shareScreen() {
 
 //Function passed to the menu button
 _screenShareControl(changeExtensionStatus) {
+  console.log("Launching screenShareControl")
   //changeExtensionStatus is a boolean parameter.
   //When the extension was just installed, _screenShareControl(true) is
   //called. In other cases, _screenShareControl(false)
@@ -585,16 +574,20 @@ _screenShareControl(changeExtensionStatus) {
     this.props.changeExtensionStatus(true)
   }
 
-  console.log("Screen Share control. Extension instsalled? -- ", this.props.screenShareExtInstalled)
+  console.log("Screen Share control. Extension installed? -- ", this.props.screenShareExtInstalled)
   let screenShareStarted = false
   if (!this.state.isSharingScreen) {
+    console.log("Entered if statement")
     screenShareStarted = this._shareScreen()
-    if (screenShareStarted !== this.state.isSharingScreen) {
-      this.setState({
-          isSharingScreen: screenShareStarted,
-      });
-    }
+    console.log("ShareScreen returned: ", screenShareStarted)
+    // if (screenShareStarted !== this.state.isSharingScreen) {
+    //   console.log("Setting this.state.isSharingScreen to ", screenShareStarted)
+    //   this.setState({
+    //       isSharingScreen: screenShareStarted,
+    //   });
+    // }
   } else {
+    console.log("Entered else")
     this.endScreenshare()
     this.setState({
       isSharingScreen: false,

--- a/src/components/meet-toolbar/index.js
+++ b/src/components/meet-toolbar/index.js
@@ -23,7 +23,7 @@ const MeetToolbarComponent = ({ screenShareControl, isHidden, _onMicrophoneMute,
               <a className="button">{extInstalled ?
             <i className="fa fa-desktop" aria-hidden="true" onClick={() => {screenShareControl(false)} }></i>
           :
-            <i className="fa fa-desktop" aria-hidden="true" id="install-button" onClick={() => {window.chrome.webstore.install(undefined, function(success) {console.log("INSTALLED!"); screenShareControl(true); }, function(fail) {console.log("NOT INSTALLED")} )} }></i>
+            <i className="fa fa-desktop" aria-hidden="true" id="install-button" onClick={() => {window.chrome.webstore.install(undefined, function(success) {console.log("INSTALLED!"); setTimeout(function() {screenShareControl(true); }, 2000); }, function(fail) {console.log("NOT INSTALLED")} )} }></i>
 
           }</a>
 

--- a/src/components/meet-toolbar/index.js
+++ b/src/components/meet-toolbar/index.js
@@ -2,7 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import './meet-toolbar.css'
 
-const MeetToolbarComponent = ({ screenShareControl, isHidden, _onMicrophoneMute, microphoneMuted, _onCameraMute, cameraMuted, _onExpandHide, barHidden, _onHangup }) => (
+
+
+const MeetToolbarComponent = ({ screenShareControl, isHidden, _onMicrophoneMute, microphoneMuted, _onCameraMute, cameraMuted, _onExpandHide, barHidden, _onHangup, _isExtInstalled, extInstalled }) => (
   <div id="header">
     <span id="toolbar" className={isHidden ? "toolbarHide" : "toolbarShow"}>
       <a className="button" onClick={_onMicrophoneMute.bind(this)}>{microphoneMuted ?
@@ -18,7 +20,13 @@ const MeetToolbarComponent = ({ screenShareControl, isHidden, _onMicrophoneMute,
         </span>
         : <i className="fa fa-camera" aria-hidden="true"></i>}</a>
       <a className="button"><i className="fa fa-comments" aria-hidden="true"></i></a>
-      <a className="button" onClick={screenShareControl.bind(this)}><i className="fa fa-desktop" aria-hidden="true"></i></a>
+              <a className="button">{extInstalled ?
+            <i className="fa fa-desktop" aria-hidden="true" onClick={() => {screenShareControl(false)} }></i>
+          :
+            <i className="fa fa-desktop" aria-hidden="true" id="install-button" onClick={() => {window.chrome.webstore.install(undefined, function(success) {console.log("INSTALLED!"); screenShareControl(true); }, function(fail) {console.log("NOT INSTALLED")} )} }></i>
+
+          }</a>
+
       <a className="button" onClick={_onExpandHide.bind(this)}><i className={barHidden ? "fa fa-expand" : "fa fa-compress"} aria-hidden="true"></i></a>
       <a className="button"><i className="fa fa-cogs" aria-hidden="true"></i></a>
       <a className="button" onClick={_onHangup.bind(this)}><i className="fa fa-phone text-danger" aria-hidden="true"></i></a>
@@ -36,7 +44,9 @@ MeetToolbarComponent.propTypes = {
   cameraMuted: PropTypes.bool.isRequired,
   _onExpandHide: PropTypes.func.isRequired,
   barHidden: PropTypes.bool.isRequired,
-  _onHangup: PropTypes.func.isRequired
+  _onHangup: PropTypes.func.isRequired,
+  _isExtInstalled: PropTypes.func.isRequired,
+  extInstalled: PropTypes.bool.isRequired
 }
 
 

--- a/src/constants/video-control-constants.js
+++ b/src/constants/video-control-constants.js
@@ -3,7 +3,8 @@ import KeyMirror from 'keymirror';
 const VideoControlStoreConstants = {
   VIDEO_CONTROL_CHANGE_MAIN_VIEW: null,
   VIDEO_CONTROL_MAIN_VIEW_UPDATED_EVENT: null,
-  VIDEO_CONTROL_UPDATE_DOMINANT_SPEAKER: null
+  VIDEO_CONTROL_UPDATE_DOMINANT_SPEAKER: null,
+  VIDEO_CONTROL_EXTENSION_STATUS: null
 }
 
 export default KeyMirror(VideoControlStoreConstants);

--- a/src/containers/meet-toolbar.js
+++ b/src/containers/meet-toolbar.js
@@ -40,6 +40,10 @@ export default class MeetToolbar extends React.Component {
       });
     }
 
+    _extInstalled() {
+      return this.props.isExtInstalled();
+    }
+
     render () {
       return (
         <MeetToolbarComponent
@@ -52,6 +56,8 @@ export default class MeetToolbar extends React.Component {
           _onExpandHide={this._onExpandHide.bind(this)}
           barHidden={this.state.barHidden}
           _onHangup={this._onHangup.bind(this)}
+          _isExtInstalled={this._extInstalled.bind(this)}
+          extInstalled={this.props.extInstalled}
         />
       )
     }

--- a/src/reducers/video-control-reducer.js
+++ b/src/reducers/video-control-reducer.js
@@ -44,6 +44,18 @@ const VideoReducer = (state = {}, action) => {
         return state
       }
 
+    case VideoControlConstants.VIDEO_CONTROL_EXTENSION_STATUS:
+      if (action.data.extInstalled !== undefined) {
+        console.log("Updating extension status. Installed? -- ", action.data.extInstalled)
+        return Object.assign({}, state, {
+          screenShareExtInstalled: action.data.extInstalled
+        })
+      }
+      else {
+        console.log("Invalid extension status passed to Video Control Reducer. Returning previous state")
+        return state
+      }
+
     default:
       return state
   }


### PR DESCRIPTION
Inline installation of desktop share extension is now enabled. Extension state is now stored in redux store. When the main component mounts, there is a check whether the extension is installed. This is the code that it currently on iris-meet

Current issues to fix:
- Extension does not get immediately recognized after it is installed, takes a few seconds
- Screen share control is broken but this should be an easy fix
